### PR TITLE
publish to custom domain

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Sphinx build
         run: |
           sphinx-build docs docs/_build/html
+          cp ./CNAME ./docs/_build/html/CNAME
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+codex.docs.wildme.org

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+codex.docs.wildme.org


### PR DESCRIPTION
follows pattern from Wildbook Docs PR: https://github.com/WildMeOrg/wildbook-docs/pull/36/files
publish to custom domain rather than default